### PR TITLE
Fix null check in partner limit retrieval

### DIFF
--- a/Homeworks/UnitTests/src/PromoCodeFactory.UnitTests/WebHost/Controllers/Partners/GetPartnerLimitAsyncTests.cs
+++ b/Homeworks/UnitTests/src/PromoCodeFactory.UnitTests/WebHost/Controllers/Partners/GetPartnerLimitAsyncTests.cs
@@ -1,0 +1,76 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using AutoFixture;
+using AutoFixture.AutoMoq;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using PromoCodeFactory.Core.Abstractions.Repositories;
+using PromoCodeFactory.Core.Domain.PromoCodeManagement;
+using PromoCodeFactory.WebHost.Controllers;
+using Xunit;
+
+namespace PromoCodeFactory.UnitTests.WebHost.Controllers.Partners
+{
+    public class GetPartnerLimitAsyncTests
+    {
+        private readonly Mock<IRepository<Partner>> _partnersRepositoryMock;
+        private readonly PartnersController _partnersController;
+
+        public GetPartnerLimitAsyncTests()
+        {
+            var fixture = new Fixture().Customize(new AutoMoqCustomization());
+            _partnersRepositoryMock = fixture.Freeze<Mock<IRepository<Partner>>>();
+            _partnersController = fixture.Build<PartnersController>().OmitAutoProperties().Create();
+        }
+
+        private Partner CreateBasePartner()
+        {
+            return new Partner
+            {
+                Id = Guid.Parse("7d994823-8226-4273-b063-1a95f3cc1df8"),
+                Name = "Суперигрушки",
+                IsActive = true,
+                PartnerLimits = new List<PartnerPromoCodeLimit>()
+                {
+                    new PartnerPromoCodeLimit
+                    {
+                        Id = Guid.Parse("e00633a5-978a-420e-a7d6-3e1dab116393"),
+                        CreateDate = new DateTime(2020, 07, 9),
+                        EndDate = new DateTime(2020, 10, 9),
+                        Limit = 100
+                    }
+                }
+            };
+        }
+
+        [Fact]
+        public async Task GetPartnerLimitAsync_PartnerIsNotFound_ReturnsNotFound()
+        {
+            var partnerId = Guid.Parse("def47943-7aaf-44a1-ae21-05aa4948b165");
+            Partner partner = null;
+
+            _partnersRepositoryMock.Setup(r => r.GetByIdAsync(partnerId))
+                .ReturnsAsync(partner);
+
+            var result = await _partnersController.GetPartnerLimitAsync(partnerId, Guid.NewGuid());
+
+            result.Result.Should().BeAssignableTo<NotFoundResult>();
+        }
+
+        [Fact]
+        public async Task GetPartnerLimitAsync_LimitIsNotFound_ReturnsNotFound()
+        {
+            var partnerId = Guid.Parse("def47943-7aaf-44a1-ae21-05aa4948b165");
+            var partner = CreateBasePartner();
+
+            _partnersRepositoryMock.Setup(r => r.GetByIdAsync(partnerId))
+                .ReturnsAsync(partner);
+
+            var result = await _partnersController.GetPartnerLimitAsync(partnerId, Guid.NewGuid());
+
+            result.Result.Should().BeAssignableTo<NotFoundResult>();
+        }
+    }
+}

--- a/Homeworks/UnitTests/src/PromoCodeFactory.WebHost/Controllers/PartnersController.cs
+++ b/Homeworks/UnitTests/src/PromoCodeFactory.WebHost/Controllers/PartnersController.cs
@@ -61,6 +61,9 @@ namespace PromoCodeFactory.WebHost.Controllers
             var limit = partner.PartnerLimits
                 .FirstOrDefault(x => x.Id == limitId);
 
+            if (limit == null)
+                return NotFound();
+
             var response = new PartnerPromoCodeLimitResponse()
             {
                 Id = limit.Id,
@@ -70,7 +73,7 @@ namespace PromoCodeFactory.WebHost.Controllers
                 EndDate = limit.EndDate.ToString("dd.MM.yyyy hh:mm:ss"),
                 CancelDate = limit.CancelDate?.ToString("dd.MM.yyyy hh:mm:ss"),
             };
-            
+
             return Ok(response);
         }
         


### PR DESCRIPTION
## Summary
- handle missing partner promo code limit in controller
- add unit tests for partner promo code limit retrieval

## Testing
- `dotnet test Homeworks/UnitTests/src/PromoCodeFactory.sln` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685e4a0281ec83279b6a844b4f57647e