### PR TITLE
Update UnitTests projects to .NET 9

### DIFF
--- a/Homeworks/UnitTests/src/PromoCodeFactory.Core/PromoCodeFactory.Core.csproj
+++ b/Homeworks/UnitTests/src/PromoCodeFactory.Core/PromoCodeFactory.Core.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net9.0</TargetFramework>
     </PropertyGroup>
 
 </Project>

--- a/Homeworks/UnitTests/src/PromoCodeFactory.DataAccess/PromoCodeFactory.DataAccess.csproj
+++ b/Homeworks/UnitTests/src/PromoCodeFactory.DataAccess/PromoCodeFactory.DataAccess.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net9.0</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Homeworks/UnitTests/src/PromoCodeFactory.UnitTests/PromoCodeFactory.UnitTests.csproj
+++ b/Homeworks/UnitTests/src/PromoCodeFactory.UnitTests/PromoCodeFactory.UnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net9.0</TargetFramework>
 
         <IsPackable>false</IsPackable>
     </PropertyGroup>

--- a/Homeworks/UnitTests/src/PromoCodeFactory.WebHost/PromoCodeFactory.WebHost.csproj
+++ b/Homeworks/UnitTests/src/PromoCodeFactory.WebHost/PromoCodeFactory.WebHost.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net9.0</TargetFramework>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <NoWarn>$(NoWarn);1591</NoWarn>
     </PropertyGroup>


### PR DESCRIPTION
## Summary
- target .NET 9 in PromoCodeFactory solution to match available runtime

## Testing
- `dotnet test Homeworks/UnitTests/src/PromoCodeFactory.UnitTests/PromoCodeFactory.UnitTests.csproj --no-build --configuration Release --logger trx` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685e9792a1c083278051e1c56d72318a